### PR TITLE
吹き飛ばし処理とHit用BoxCollider一部抜け修正と5Pと6Pのロゴ抜け修正

### DIFF
--- a/Assets/Materials/Player_5/Logo_5.mat
+++ b/Assets/Materials/Player_5/Logo_5.mat
@@ -39,7 +39,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: c30a637009842fa44a6ba3bcb2c500a5, type: 3}
+        m_Texture: {fileID: 2800000, guid: 3a7cb571b1d59e94b8cad690524548e2, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:

--- a/Assets/Materials/Player_6/Logo_6.mat
+++ b/Assets/Materials/Player_6/Logo_6.mat
@@ -39,7 +39,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: c30a637009842fa44a6ba3bcb2c500a5, type: 3}
+        m_Texture: {fileID: 2800000, guid: 37fcded7067ca8848b2194761a905042, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:

--- a/Assets/Prefabs/Ano/FireEffect/FireBall.prefab
+++ b/Assets/Prefabs/Ano/FireEffect/FireBall.prefab
@@ -43,7 +43,7 @@ GameObject:
   - component: {fileID: 54044381311838570}
   m_Layer: 0
   m_Name: FireBall
-  m_TagString: Untagged
+  m_TagString: OutsideColl
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -55,7 +55,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1822514340354904}
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 50, z: 0}
   m_LocalScale: {x: 2.5, y: 2.5, z: 2.5}
   m_Children:
   - {fileID: 4971982648763946}

--- a/Assets/Prefabs/Date/Human_1.prefab
+++ b/Assets/Prefabs/Date/Human_1.prefab
@@ -235,7 +235,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4505662829159962}
   - component: {fileID: 65481326458861378}
-  - component: {fileID: 114611459156372346}
+  - component: {fileID: 114566635016403594}
   m_Layer: 0
   m_Name: Hand_R_end
   m_TagString: Untagged
@@ -287,7 +287,8 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 4138448790373018}
-  - component: {fileID: 114654391083936974}
+  - component: {fileID: 65700191253065846}
+  - component: {fileID: 114157692086531764}
   m_Layer: 0
   m_Name: Calf_L_end
   m_TagString: Untagged
@@ -320,7 +321,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4366787398948590}
   - component: {fileID: 65468789653427796}
-  - component: {fileID: 114712997555584432}
+  - component: {fileID: 114849906645061510}
   m_Layer: 0
   m_Name: Hand_L_end
   m_TagString: Untagged
@@ -551,7 +552,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4453656576189842}
   - component: {fileID: 65502563675886340}
-  - component: {fileID: 114317033539195738}
+  - component: {fileID: 114679946566181858}
   m_Layer: 0
   m_Name: Calf_R_end
   m_TagString: Untagged
@@ -2012,6 +2013,18 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.003, y: 0.005, z: 0.005}
   m_Center: {x: -0.0005, y: 0.004, z: 0.0005}
+--- !u!65 &65700191253065846
+BoxCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1463074639488696}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.005, y: 0.007, z: 0.005}
+  m_Center: {x: 0, y: -0.002, z: 0}
 --- !u!65 &65736451843845886
 BoxCollider:
   m_ObjectHideFlags: 1
@@ -2101,6 +2114,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_playerID: 1
+  myInputManager: {fileID: 0}
   m_bodyObj: {fileID: 1763243969287568}
   m_rightHandObj: {fileID: 1520951434441310}
   m_leftHandObj: {fileID: 1818568241125366}
@@ -2127,22 +2141,26 @@ MonoBehaviour:
     decayForce: {x: 0.99, y: 0, z: 0}
   m_directionAngle: 250
   rayTest: {fileID: 114323927281537114}
---- !u!114 &114317033539195738
+--- !u!114 &114157692086531764
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1870525167091920}
+  m_GameObject: {fileID: 1463074639488696}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
   audio: {fileID: 0}
   P_Controller: {fileID: 114144124142180806}
   PlayNum: 1
-  CriticalFlag: 0
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
 --- !u!114 &114323927281537114
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2178,7 +2196,7 @@ MonoBehaviour:
   Pattern: 0
   DefaultMode: 0
   DebugMode: 1
---- !u!114 &114611459156372346
+--- !u!114 &114566635016403594
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
@@ -2186,46 +2204,38 @@ MonoBehaviour:
   m_GameObject: {fileID: 1413560394217552}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
   audio: {fileID: 0}
   P_Controller: {fileID: 114144124142180806}
   PlayNum: 1
-  CriticalFlag: 0
---- !u!114 &114654391083936974
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
+--- !u!114 &114679946566181858
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1463074639488696}
+  m_GameObject: {fileID: 1870525167091920}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
   audio: {fileID: 0}
   P_Controller: {fileID: 114144124142180806}
   PlayNum: 1
-  CriticalFlag: 0
---- !u!114 &114712997555584432
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1502121769898822}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
-  audio: {fileID: 0}
-  P_Controller: {fileID: 114144124142180806}
-  PlayNum: 1
-  CriticalFlag: 0
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
 --- !u!114 &114737147816298602
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2247,6 +2257,26 @@ MonoBehaviour:
   bodyWeight: 0
   headWeight: 0
   eyeWeight: 0
+--- !u!114 &114849906645061510
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1502121769898822}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
+  audio: {fileID: 0}
+  P_Controller: {fileID: 114144124142180806}
+  PlayNum: 1
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
 --- !u!137 &137583162914089480
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Date/Human_2.prefab
+++ b/Assets/Prefabs/Date/Human_2.prefab
@@ -37,7 +37,8 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 4949855123214086}
-  - component: {fileID: 114636474480042632}
+  - component: {fileID: 65012013110867352}
+  - component: {fileID: 114701586676745998}
   m_Layer: 0
   m_Name: Calf_R_end
   m_TagString: Untagged
@@ -444,7 +445,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4591997984174080}
   - component: {fileID: 65509719328516594}
-  - component: {fileID: 114010153179741828}
+  - component: {fileID: 114761058017675996}
   m_Layer: 0
   m_Name: Hand_L_end
   m_TagString: Untagged
@@ -533,7 +534,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4671936987801194}
   - component: {fileID: 65958113480589544}
-  - component: {fileID: 114701983295150520}
+  - component: {fileID: 114363728298590476}
   m_Layer: 0
   m_Name: Calf_L_end
   m_TagString: Untagged
@@ -550,7 +551,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4159809957608450}
   - component: {fileID: 65036349338028358}
-  - component: {fileID: 114099277538811942}
+  - component: {fileID: 114912355907915232}
   m_Layer: 0
   m_Name: Hand_R_end
   m_TagString: Untagged
@@ -1748,6 +1749,18 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.0035, y: 0.005, z: 0.005}
   m_Center: {x: 0.0001, y: 0.0015, z: -0.0005}
+--- !u!65 &65012013110867352
+BoxCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1054767266322098}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.005, y: 0.007, z: 0.005}
+  m_Center: {x: 0, y: -0.002, z: 0}
 --- !u!65 &65036349338028358
 BoxCollider:
   m_ObjectHideFlags: 1
@@ -2089,38 +2102,6 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
---- !u!114 &114010153179741828
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1606121744520962}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
-  audio: {fileID: 0}
-  P_Controller: {fileID: 114387306285487334}
-  PlayNum: 2
-  CriticalFlag: 0
---- !u!114 &114099277538811942
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1794317998877610}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
-  audio: {fileID: 0}
-  P_Controller: {fileID: 114387306285487334}
-  PlayNum: 2
-  CriticalFlag: 0
 --- !u!114 &114184571854150478
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2156,6 +2137,26 @@ MonoBehaviour:
   Pattern: 0
   DefaultMode: 0
   DebugMode: 1
+--- !u!114 &114363728298590476
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1721274678899840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
+  audio: {fileID: 0}
+  P_Controller: {fileID: 114387306285487334}
+  PlayNum: 2
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
 --- !u!114 &114378733908616502
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2189,6 +2190,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_playerID: 2
+  myInputManager: {fileID: 0}
   m_bodyObj: {fileID: 1313503552564812}
   m_rightHandObj: {fileID: 1278942666615170}
   m_leftHandObj: {fileID: 1996879063588266}
@@ -2215,7 +2217,7 @@ MonoBehaviour:
     decayForce: {x: 0.99, y: 0, z: 0}
   m_directionAngle: 250
   rayTest: {fileID: 114184571854150478}
---- !u!114 &114636474480042632
+--- !u!114 &114701586676745998
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
@@ -2223,30 +2225,58 @@ MonoBehaviour:
   m_GameObject: {fileID: 1054767266322098}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
   audio: {fileID: 0}
   P_Controller: {fileID: 114387306285487334}
-  PlayNum: 1
-  CriticalFlag: 0
---- !u!114 &114701983295150520
+  PlayNum: 2
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
+--- !u!114 &114761058017675996
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1721274678899840}
+  m_GameObject: {fileID: 1606121744520962}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
   audio: {fileID: 0}
   P_Controller: {fileID: 114387306285487334}
   PlayNum: 2
-  CriticalFlag: 0
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
+--- !u!114 &114912355907915232
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1794317998877610}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
+  audio: {fileID: 0}
+  P_Controller: {fileID: 114387306285487334}
+  PlayNum: 2
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
 --- !u!137 &137943412658688840
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Date/Human_3.prefab
+++ b/Assets/Prefabs/Date/Human_3.prefab
@@ -82,7 +82,8 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 4196551668096762}
-  - component: {fileID: 114968532080738316}
+  - component: {fileID: 65668667072663012}
+  - component: {fileID: 114345981751508848}
   m_Layer: 0
   m_Name: Calf_L_end
   m_TagString: Untagged
@@ -390,7 +391,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4516836950120042}
   - component: {fileID: 65201530690423016}
-  - component: {fileID: 114710638677050646}
+  - component: {fileID: 114871821236064592}
   m_Layer: 0
   m_Name: Hand_L_end
   m_TagString: Untagged
@@ -407,7 +408,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4788097166626484}
   - component: {fileID: 65886834915052224}
-  - component: {fileID: 114312815652472780}
+  - component: {fileID: 114203026043696712}
   m_Layer: 0
   m_Name: Hand_R_end
   m_TagString: Untagged
@@ -528,7 +529,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4464047433424358}
   - component: {fileID: 65473819005690142}
-  - component: {fileID: 114041238138968326}
+  - component: {fileID: 114439653574390632}
   m_Layer: 0
   m_Name: Calf_R_end
   m_TagString: Untagged
@@ -1964,6 +1965,18 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.003, y: 0.005, z: 0.007}
   m_Center: {x: 0.0003, y: 0.0035, z: -0.0007}
+--- !u!65 &65668667072663012
+BoxCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1070157161678834}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.005, y: 0.007, z: 0.005}
+  m_Center: {x: 0, y: -0.002, z: 0}
 --- !u!65 &65683749913347228
 BoxCollider:
   m_ObjectHideFlags: 1
@@ -2089,23 +2102,7 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
---- !u!114 &114041238138968326
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1797841727176520}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
-  audio: {fileID: 0}
-  P_Controller: {fileID: 114790839890748216}
-  PlayNum: 3
-  CriticalFlag: 0
---- !u!114 &114312815652472780
+--- !u!114 &114203026043696712
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
@@ -2113,14 +2110,38 @@ MonoBehaviour:
   m_GameObject: {fileID: 1527626208408854}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
   audio: {fileID: 0}
   P_Controller: {fileID: 114790839890748216}
   PlayNum: 3
-  CriticalFlag: 0
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
+--- !u!114 &114345981751508848
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1070157161678834}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
+  audio: {fileID: 0}
+  P_Controller: {fileID: 114790839890748216}
+  PlayNum: 3
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
 --- !u!114 &114415427302768312
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2142,6 +2163,26 @@ MonoBehaviour:
   bodyWeight: 0
   headWeight: 0
   eyeWeight: 0
+--- !u!114 &114439653574390632
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1797841727176520}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
+  audio: {fileID: 0}
+  P_Controller: {fileID: 114790839890748216}
+  PlayNum: 3
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
 --- !u!114 &114506581498648074
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2177,22 +2218,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rayDistance: 2
   layerMaskName: Ground
---- !u!114 &114710638677050646
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1501338357674802}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
-  audio: {fileID: 0}
-  P_Controller: {fileID: 114790839890748216}
-  PlayNum: 3
-  CriticalFlag: 0
 --- !u!114 &114790839890748216
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2205,6 +2230,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_playerID: 3
+  myInputManager: {fileID: 0}
   m_bodyObj: {fileID: 1404075687510486}
   m_rightHandObj: {fileID: 1952209557560008}
   m_leftHandObj: {fileID: 1926058626592222}
@@ -2231,22 +2257,26 @@ MonoBehaviour:
     decayForce: {x: 0.99, y: 0, z: 0}
   m_directionAngle: 250
   rayTest: {fileID: 114656022787043098}
---- !u!114 &114968532080738316
+--- !u!114 &114871821236064592
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1070157161678834}
+  m_GameObject: {fileID: 1501338357674802}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
   audio: {fileID: 0}
   P_Controller: {fileID: 114790839890748216}
   PlayNum: 3
-  CriticalFlag: 0
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
 --- !u!137 &137243538249828078
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Date/Human_4.prefab
+++ b/Assets/Prefabs/Date/Human_4.prefab
@@ -76,8 +76,8 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 4434193199004674}
-  - component: {fileID: 114663132879891354}
   - component: {fileID: 65615613383889904}
+  - component: {fileID: 114423651523320952}
   m_Layer: 0
   m_Name: Hand_L_end
   m_TagString: Untagged
@@ -109,7 +109,8 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 4256070663585024}
-  - component: {fileID: 114502798934687794}
+  - component: {fileID: 65342735226325190}
+  - component: {fileID: 114167720144600634}
   m_Layer: 0
   m_Name: Calf_L_end
   m_TagString: Untagged
@@ -226,7 +227,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4453311690325214}
   - component: {fileID: 65870716020999948}
-  - component: {fileID: 114199894451599436}
+  - component: {fileID: 114156436049858422}
   m_Layer: 0
   m_Name: Calf_R_end
   m_TagString: Untagged
@@ -243,7 +244,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4794979347149234}
   - component: {fileID: 65280656262569320}
-  - component: {fileID: 114759326018657644}
+  - component: {fileID: 114058108325184460}
   m_Layer: 0
   m_Name: Hand_R_end
   m_TagString: Untagged
@@ -1844,6 +1845,18 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.013, y: 0.007, z: 0.006}
   m_Center: {x: 0, y: 0.0035, z: 0}
+--- !u!65 &65342735226325190
+BoxCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1147490955140966}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.005, y: 0.007, z: 0.005}
+  m_Center: {x: 0, y: -0.002, z: 0}
 --- !u!65 &65413936040755146
 BoxCollider:
   m_ObjectHideFlags: 1
@@ -2089,6 +2102,26 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
+--- !u!114 &114058108325184460
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1339757140163394}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
+  audio: {fileID: 0}
+  P_Controller: {fileID: 114376492249141510}
+  PlayNum: 4
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
 --- !u!114 &114152905965822594
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2102,7 +2135,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rayDistance: 2
   layerMaskName: Ground
---- !u!114 &114199894451599436
+--- !u!114 &114156436049858422
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
@@ -2110,14 +2143,38 @@ MonoBehaviour:
   m_GameObject: {fileID: 1305270388735748}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
   audio: {fileID: 0}
   P_Controller: {fileID: 114376492249141510}
   PlayNum: 4
-  CriticalFlag: 0
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
+--- !u!114 &114167720144600634
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1147490955140966}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
+  audio: {fileID: 0}
+  P_Controller: {fileID: 114376492249141510}
+  PlayNum: 4
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
 --- !u!114 &114360007746449226
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2173,6 +2230,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_playerID: 4
+  myInputManager: {fileID: 0}
   m_bodyObj: {fileID: 1127312982964314}
   m_rightHandObj: {fileID: 1462539098495450}
   m_leftHandObj: {fileID: 1652172357805778}
@@ -2199,23 +2257,7 @@ MonoBehaviour:
     decayForce: {x: 0.99, y: 0, z: 0}
   m_directionAngle: 250
   rayTest: {fileID: 114152905965822594}
---- !u!114 &114502798934687794
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1147490955140966}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
-  audio: {fileID: 0}
-  P_Controller: {fileID: 114376492249141510}
-  PlayNum: 4
-  CriticalFlag: 0
---- !u!114 &114663132879891354
+--- !u!114 &114423651523320952
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
@@ -2223,30 +2265,18 @@ MonoBehaviour:
   m_GameObject: {fileID: 1130013290703226}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
   audio: {fileID: 0}
   P_Controller: {fileID: 114376492249141510}
   PlayNum: 4
-  CriticalFlag: 0
---- !u!114 &114759326018657644
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1339757140163394}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
-  audio: {fileID: 0}
-  P_Controller: {fileID: 114376492249141510}
-  PlayNum: 4
-  CriticalFlag: 0
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
 --- !u!137 &137197677056036714
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Date/Human_5.prefab
+++ b/Assets/Prefabs/Date/Human_5.prefab
@@ -52,7 +52,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4756868849470772}
   - component: {fileID: 65208780944174332}
-  - component: {fileID: 114440991155882378}
+  - component: {fileID: 114501239651584760}
   m_Layer: 0
   m_Name: Hand_R_end
   m_TagString: Untagged
@@ -68,8 +68,8 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 4327678365872402}
-  - component: {fileID: 114196133014051072}
   - component: {fileID: 65988068543571920}
+  - component: {fileID: 114183162267870622}
   m_Layer: 0
   m_Name: Calf_L_end
   m_TagString: Untagged
@@ -101,7 +101,8 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 4330119531818710}
-  - component: {fileID: 114857677323406964}
+  - component: {fileID: 65588491285569914}
+  - component: {fileID: 114712053345384776}
   m_Layer: 0
   m_Name: Calf_R_end
   m_TagString: Untagged
@@ -614,8 +615,8 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 4217956364633916}
-  - component: {fileID: 114247234530136084}
   - component: {fileID: 65143281558993874}
+  - component: {fileID: 114877016538299750}
   m_Layer: 0
   m_Name: Hand_L_end
   m_TagString: Untagged
@@ -1940,6 +1941,18 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.004, y: 0.0035, z: 0.006}
   m_Center: {x: 0, y: 0.004, z: 0}
+--- !u!65 &65588491285569914
+BoxCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1102059842342064}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.005, y: 0.007, z: 0.005}
+  m_Center: {x: 0, y: -0.002, z: 0}
 --- !u!65 &65607435424815232
 BoxCollider:
   m_ObjectHideFlags: 1
@@ -2101,6 +2114,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_playerID: 5
+  myInputManager: {fileID: 0}
   m_bodyObj: {fileID: 1358513346199156}
   m_rightHandObj: {fileID: 1710649902959348}
   m_leftHandObj: {fileID: 1899395220044010}
@@ -2149,7 +2163,7 @@ MonoBehaviour:
   Pattern: 0
   DefaultMode: 0
   DebugMode: 1
---- !u!114 &114196133014051072
+--- !u!114 &114183162267870622
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
@@ -2157,30 +2171,18 @@ MonoBehaviour:
   m_GameObject: {fileID: 1091397880861936}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
   audio: {fileID: 0}
   P_Controller: {fileID: 114143052832651144}
   PlayNum: 5
-  CriticalFlag: 0
---- !u!114 &114247234530136084
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1954948457929946}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
-  audio: {fileID: 0}
-  P_Controller: {fileID: 114143052832651144}
-  PlayNum: 5
-  CriticalFlag: 0
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
 --- !u!114 &114348906947774610
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2202,7 +2204,7 @@ MonoBehaviour:
   bodyWeight: 0
   headWeight: 0
   eyeWeight: 0
---- !u!114 &114440991155882378
+--- !u!114 &114501239651584760
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
@@ -2210,15 +2212,19 @@ MonoBehaviour:
   m_GameObject: {fileID: 1089233056531978}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
   audio: {fileID: 0}
   P_Controller: {fileID: 114143052832651144}
   PlayNum: 5
-  CriticalFlag: 0
---- !u!114 &114857677323406964
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
+--- !u!114 &114712053345384776
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
@@ -2226,14 +2232,38 @@ MonoBehaviour:
   m_GameObject: {fileID: 1102059842342064}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
   audio: {fileID: 0}
   P_Controller: {fileID: 114143052832651144}
   PlayNum: 5
-  CriticalFlag: 0
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
+--- !u!114 &114877016538299750
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1954948457929946}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
+  audio: {fileID: 0}
+  P_Controller: {fileID: 114143052832651144}
+  PlayNum: 5
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
 --- !u!114 &114978070204711190
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Date/Human_6.prefab
+++ b/Assets/Prefabs/Date/Human_6.prefab
@@ -127,8 +127,8 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 4183461815620254}
-  - component: {fileID: 114916053750859648}
   - component: {fileID: 65894104778992830}
+  - component: {fileID: 114719450221145474}
   m_Layer: 0
   m_Name: Hand_L_end
   m_TagString: Untagged
@@ -180,7 +180,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4910297441591376}
   - component: {fileID: 65485888792391984}
-  - component: {fileID: 114489039102626328}
+  - component: {fileID: 114268152802299160}
   m_Layer: 0
   m_Name: Hand_R_end
   m_TagString: Untagged
@@ -415,7 +415,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4533207964020430}
   - component: {fileID: 65236660984976322}
-  - component: {fileID: 114381497896364794}
+  - component: {fileID: 114595034991501098}
   m_Layer: 0
   m_Name: Calf_R_end
   m_TagString: Untagged
@@ -478,8 +478,8 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 4474457139217008}
-  - component: {fileID: 114065144658771328}
   - component: {fileID: 65453411488215730}
+  - component: {fileID: 114856401641176756}
   m_Layer: 0
   m_Name: Calf_L_end
   m_TagString: Untagged
@@ -2102,22 +2102,26 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
---- !u!114 &114065144658771328
+--- !u!114 &114268152802299160
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1774429048092878}
+  m_GameObject: {fileID: 1355684406830848}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
   audio: {fileID: 0}
   P_Controller: {fileID: 114745635048470910}
   PlayNum: 6
-  CriticalFlag: 0
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
 --- !u!114 &114302950340732178
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2131,22 +2135,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rayDistance: 2
   layerMaskName: Ground
---- !u!114 &114381497896364794
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1625008542486786}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
-  audio: {fileID: 0}
-  P_Controller: {fileID: 114745635048470910}
-  PlayNum: 6
-  CriticalFlag: 0
 --- !u!114 &114468569754795686
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2168,22 +2156,26 @@ MonoBehaviour:
   bodyWeight: 0
   headWeight: 0
   eyeWeight: 0
---- !u!114 &114489039102626328
+--- !u!114 &114595034991501098
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1355684406830848}
+  m_GameObject: {fileID: 1625008542486786}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
   audio: {fileID: 0}
   P_Controller: {fileID: 114745635048470910}
   PlayNum: 6
-  CriticalFlag: 0
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
 --- !u!114 &114680210371607022
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2206,6 +2198,26 @@ MonoBehaviour:
   Pattern: 0
   DefaultMode: 0
   DebugMode: 1
+--- !u!114 &114719450221145474
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1252781861182302}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
+  audio: {fileID: 0}
+  P_Controller: {fileID: 114745635048470910}
+  PlayNum: 6
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
 --- !u!114 &114745635048470910
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2218,6 +2230,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_playerID: 6
+  myInputManager: {fileID: 0}
   m_bodyObj: {fileID: 1449480356525946}
   m_rightHandObj: {fileID: 1194157642573444}
   m_leftHandObj: {fileID: 1814654181169048}
@@ -2244,22 +2257,26 @@ MonoBehaviour:
     decayForce: {x: 0.99, y: 0, z: 0}
   m_directionAngle: 250
   rayTest: {fileID: 114302950340732178}
---- !u!114 &114916053750859648
+--- !u!114 &114856401641176756
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1252781861182302}
+  m_GameObject: {fileID: 1774429048092878}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e886921cec040f4d9b4f65772e30cd1, type: 3}
+  m_Script: {fileID: 11500000, guid: 8bd77553283479e449c04f52d0560c20, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
+  CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+    type: 2}
   audio: {fileID: 0}
   P_Controller: {fileID: 114745635048470910}
   PlayNum: 6
-  CriticalFlag: 0
+  CriticalProbability: 20
+  HitPower: 20
+  CriticalPower: 40
 --- !u!137 &137895979734281560
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 1

--- a/Assets/Scenes/TestScene/AnoScene.unity
+++ b/Assets/Scenes/TestScene/AnoScene.unity
@@ -128,7 +128,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &48175409
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -152,7 +152,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &213255630
 Prefab:
@@ -484,53 +484,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 60, y: 0, z: 0}
---- !u!1001 &1003125093
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4064583889948694, guid: 95537e0fd822b8f4ebdc507d5bc89986, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 4064583889948694, guid: 95537e0fd822b8f4ebdc507d5bc89986, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4064583889948694, guid: 95537e0fd822b8f4ebdc507d5bc89986, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4064583889948694, guid: 95537e0fd822b8f4ebdc507d5bc89986, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4064583889948694, guid: 95537e0fd822b8f4ebdc507d5bc89986, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 4064583889948694, guid: 95537e0fd822b8f4ebdc507d5bc89986, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 4064583889948694, guid: 95537e0fd822b8f4ebdc507d5bc89986, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4064583889948694, guid: 95537e0fd822b8f4ebdc507d5bc89986, type: 2}
-      propertyPath: m_RootOrder
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 114387306285487334, guid: 95537e0fd822b8f4ebdc507d5bc89986,
-        type: 2}
-      propertyPath: myInputManager
-      value: 
-      objectReference: {fileID: 213255632}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 95537e0fd822b8f4ebdc507d5bc89986, type: 2}
-  m_IsPrefabParent: 0
 --- !u!1001 &1436483153
 Prefab:
   m_ObjectHideFlags: 0
@@ -699,50 +652,3 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1844442750
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4309942965725276, guid: 27856c8625bae1e47ba1e4c5a9315383, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4309942965725276, guid: 27856c8625bae1e47ba1e4c5a9315383, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4309942965725276, guid: 27856c8625bae1e47ba1e4c5a9315383, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4309942965725276, guid: 27856c8625bae1e47ba1e4c5a9315383, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 4309942965725276, guid: 27856c8625bae1e47ba1e4c5a9315383, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4309942965725276, guid: 27856c8625bae1e47ba1e4c5a9315383, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4309942965725276, guid: 27856c8625bae1e47ba1e4c5a9315383, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 4309942965725276, guid: 27856c8625bae1e47ba1e4c5a9315383, type: 2}
-      propertyPath: m_RootOrder
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 114144124142180806, guid: 27856c8625bae1e47ba1e4c5a9315383,
-        type: 2}
-      propertyPath: myInputManager
-      value: 
-      objectReference: {fileID: 213255632}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 27856c8625bae1e47ba1e4c5a9315383, type: 2}
-  m_IsPrefabParent: 0

--- a/Assets/Scripts/Ano/EffectCreateTest.cs
+++ b/Assets/Scripts/Ano/EffectCreateTest.cs
@@ -13,9 +13,9 @@ public class EffectCreateTest : MonoBehaviour {
 	// Update is called once per frame
 	void Update () {
         GameObject CreateObject;
-        this.transform.position=new Vector3(Random.Range(-30,30),20, Random.Range(-30, 30));
+        this.transform.position=new Vector3(Random.Range(-20,20),20, Random.Range(-20, 20));
         NowTime += Time.deltaTime;
-        if (NowTime>=2)
+        if (NowTime>=1)
         {
             CreateObject = (GameObject)Instantiate(Prefab, transform.position, Quaternion.identity);
             CreateObject.GetComponent<Transform>().LookAt(this.transform.position);

--- a/Assets/Scripts/Ano/HitSystem.cs
+++ b/Assets/Scripts/Ano/HitSystem.cs
@@ -1,0 +1,263 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class HitSystem : MonoBehaviour {
+    private enum HitSelect { Hit,Critical};
+    //生成するPrefab
+    public GameObject HitPrefab;
+    public GameObject CriticalPrefab;
+    //オーディオ
+    public AudioManager audio;
+    //エフェクト
+    private ParticleSystem HitParticle;
+    //動的生成用
+    private GameObject NewHitEffect;
+    //キャラクターのID取得
+    public PlayerController P_Controller;
+    //エフェクト発生中か
+    private bool HitEffectFlag = false;
+    //プレイヤーID一致用
+    public int PlayNum = 1;
+    //ちょっと多段ヒットしているので一時的に時間で制御
+    private float DelayTime = 2.0f;
+    private float countTime = 0;
+    [Range(0, 100)]
+    public int CriticalProbability = 20;
+    [Range(0, 100)]
+    public int HitPower = 20;
+    [Range(0, 100)]
+    public int CriticalPower = 40;
+    private bool TimeFlag = false;
+
+    void OnTriggerStay(Collider other)
+    {
+        //レイヤーの名前取得
+        string LayerName = LayerMask.LayerToName(other.gameObject.layer);
+        if (!HitEffectFlag)
+        {
+            //プレイヤーの体判定の部位
+            if (LayerName == "Player_Chest")
+            {
+                //SE再生
+                PlaysSe();
+                //Effect生成
+                CreateEffect(HitType(other.gameObject),other.gameObject.transform);
+                //エフェクト発生
+                HitEffectFlag = true;
+                HitParticle.Play();
+                return;
+            }
+            //プレイヤーの体判定
+            if (
+                (LayerName == "Player_1") ||
+                (LayerName == "Player_2") ||
+                (LayerName == "Player_3") ||
+                (LayerName == "Player_4") ||
+                (LayerName == "Player_5") ||
+                (LayerName == "Player_6"))
+            {
+                //自分には判定しない
+                switch (LayerName)
+                {
+                    case "Player_1":
+                        if (PlayNum != P_Controller.PlayerID)
+                        {
+                            //SE再生
+                            PlaysSe();
+                            //Effect生成
+                            CreateEffect(HitType(other.gameObject),other.gameObject.transform);
+                            //エフェクト発生
+                            HitEffectFlag = true;
+                            HitParticle.Play();
+                            return;
+                        }
+                        break;
+                    case "Player_2":
+                        if (PlayNum != P_Controller.PlayerID)
+                        {
+                            //SE再生
+                            PlaysSe();
+                            //Effect生成
+                            CreateEffect(HitType(other.gameObject),other.gameObject.transform);
+                            //エフェクト発生
+                            HitEffectFlag = true;
+                            HitParticle.Play();
+                            return;
+                        }
+                        break;
+                    case "Player_3":
+                        if (PlayNum != P_Controller.PlayerID)
+                        {
+                            //SE再生
+                            PlaysSe();
+                            //Effect生成
+                            CreateEffect(HitType(other.gameObject),other.gameObject.transform);
+                            //エフェクト発生
+                            HitEffectFlag = true;
+                            HitParticle.Play();
+                            return;
+                        }
+                        break;
+                    case "Player_4":
+
+                        if (PlayNum != P_Controller.PlayerID)
+                        {
+                            //SE再生
+                            PlaysSe();
+                            //Effect生成
+                            CreateEffect(HitType(other.gameObject),other.gameObject.transform);
+                            //エフェクト発生
+                            HitEffectFlag = true;
+                            HitParticle.Play();
+                            return;
+                        }
+                        break;
+                    case "Player_5":
+                        if (PlayNum != P_Controller.PlayerID)
+                        {
+                            //SE再生
+                            PlaysSe();
+                            //Effect生成
+                            CreateEffect(HitType(other.gameObject),other.gameObject.transform);
+                            //エフェクト発生
+                            HitEffectFlag = true;
+                            HitParticle.Play();
+                            return;
+                        }
+                        break;
+                    case "Player_6":
+                        if (PlayNum != P_Controller.PlayerID)
+                        {
+                            //SE再生
+                            PlaysSe();
+                            //Effect生成
+                            CreateEffect(HitType(other.gameObject),other.gameObject.transform);
+                            //エフェクト発生
+                            HitEffectFlag = true;
+                            HitParticle.Play();
+                            return;
+                        }
+                        break;
+                }
+
+            }
+
+        }
+
+    }
+    void OnTriggerExit(Collider other)
+    {
+        //レイヤーの名前取得
+        string LayerName = LayerMask.LayerToName(other.gameObject.layer);
+
+        if ((LayerName == "Player_Chest") ||
+            (LayerName == "Player_1") ||
+            (LayerName == "Player_2") ||
+            (LayerName == "Player_3") ||
+            (LayerName == "Player_4") ||
+            (LayerName == "Player_5") ||
+            (LayerName == "Player_6"))
+        {
+            //時間経過でEffect再生
+            if (TimeFlag)
+            {
+                HitEffectFlag = false;
+                TimeFlag = false;
+            }
+        }
+
+    }
+    // Use this for initialization
+    void Start () {
+		
+	}
+	
+	// Update is called once per frame
+	void Update () {
+        //再生させてから時間測定
+        if (HitEffectFlag)
+        {
+            countTime += Time.deltaTime;
+        }
+        //一定時間経過で0に戻して発生可能にする
+        if (countTime > DelayTime)
+        {
+            TimeFlag = true;
+            countTime = 0;
+        }
+        //エフェクトが動的に作られていて再生終わっていたら消す
+        if (NewHitEffect != null)
+        {
+            try
+            {
+                if (!NewHitEffect.GetComponent<ParticleSystem>().isPlaying)
+                {
+                    Destroy(NewHitEffect);
+                }
+            }
+            catch
+            {
+
+            }
+        }
+    }
+    //SE再生処理
+    private void PlaysSe()
+    {
+        //仮に使っているので新しいSEが届き次第変更
+        AudioManager.GetInstance.PlaySE0(AUDIO.SE_Hit01);
+    }
+    //Hitの種類選択
+    private HitSelect HitType(GameObject HitObject)
+    {
+        Debug.Log("Hitしました");
+        if ((HitObject.name=="Haad")||
+            (HitObject.name == "Chest") ||
+            (HitObject.name == "Lower"))
+        {
+            int Probability = Random.Range(0, 100);
+            Debug.Log(Probability);
+            if (Probability <= CriticalProbability)
+            {
+                BlowAway(HitObject,HitSelect.Critical);
+                return HitSelect.Critical;
+            }
+        }
+        BlowAway(HitObject,HitSelect.Hit);
+        return HitSelect.Hit;
+    }
+    //吹き飛ばし処理
+    private void BlowAway(GameObject HitObject, HitSelect EffectType)
+    {
+        //親のRigidbodyを探す
+        Rigidbody HitRigid = HitObject.transform.root.gameObject.GetComponent<Rigidbody>();
+        switch (EffectType)
+        {
+            case HitSelect.Hit:
+                //AddForceを入れる（衝撃を与えるのでForceModeはImpulse
+                HitRigid.AddForce(this.transform.position* HitPower, ForceMode.Impulse);
+                break;
+            case HitSelect.Critical:
+                //AddForceを入れる（衝撃を与えるのでForceModeはImpulse
+                HitRigid.AddForce(this.transform.position * CriticalPower, ForceMode.Impulse);
+                break;
+        }
+    }
+    //エフェクト生成処理
+    private void CreateEffect(HitSelect EffectType,Transform trans)
+    {
+        switch(EffectType)
+        {
+            case HitSelect.Hit:
+                NewHitEffect = (GameObject)Instantiate(HitPrefab, transform.position, Quaternion.identity);
+                break;
+            case HitSelect.Critical:
+                NewHitEffect = (GameObject)Instantiate(CriticalPrefab, transform.position, Quaternion.identity);
+                break;
+        }
+        NewHitEffect.GetComponent<Transform>().LookAt(trans);
+        HitParticle = NewHitEffect.GetComponent<ParticleSystem>();
+        //NewHitEffect.GetComponent<Transform>().localScale = new Vector3(1, 1, 1);
+    }
+}

--- a/Assets/Scripts/Ano/HitSystem.cs.meta
+++ b/Assets/Scripts/Ano/HitSystem.cs.meta
@@ -1,0 +1,19 @@
+fileFormatVersion: 2
+guid: 8bd77553283479e449c04f52d0560c20
+timeCreated: 1541926407
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - HitPrefab: {fileID: 1980582110774726, guid: 02ffff334dbbaf84cbdd72f66a3c38d8,
+      type: 2}
+  - CriticalPrefab: {fileID: 1788356027982392, guid: 9bd35d4858264da41a2fe184d925a1d8,
+      type: 2}
+  - audio: {instanceID: 0}
+  - P_Controller: {instanceID: 0}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
吹き飛ばし処理を追加と共にスプリプトをHitEffectからHitSystemに変更し、
クリティカルと通常のエフェクト発生処理を合わせました。
全Humanに追加したので競合起きないかチェックお願いします。
5Pと6Pのロゴが前のままだったので変えました。