### PR TITLE
Hitして吹き飛んでいる間地面につくまでHitし、Effect角度おかしいの修正しました

### DIFF
--- a/Assets/Scenes/TestScene/AnoScene.unity
+++ b/Assets/Scenes/TestScene/AnoScene.unity
@@ -152,7 +152,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &213255630
 Prefab:
@@ -283,6 +283,16 @@ Prefab:
       propertyPath: m_gameSceneController
       value: 
       objectReference: {fileID: 213255633}
+    - target: {fileID: 114562380259625914, guid: dc1de046339e85049a4a76553bc9f8c9,
+        type: 2}
+      propertyPath: m_debugMode.m_debugPlayerNum
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114562380259625914, guid: dc1de046339e85049a4a76553bc9f8c9,
+        type: 2}
+      propertyPath: m_debugMode.m_debugMode
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: dc1de046339e85049a4a76553bc9f8c9, type: 2}
   m_IsPrefabParent: 0
@@ -324,6 +334,48 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SceneChangeTime: 30
+--- !u!1001 &374583320
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4309942965725276, guid: 27856c8625bae1e47ba1e4c5a9315383, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4309942965725276, guid: 27856c8625bae1e47ba1e4c5a9315383, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4309942965725276, guid: 27856c8625bae1e47ba1e4c5a9315383, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4309942965725276, guid: 27856c8625bae1e47ba1e4c5a9315383, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 4309942965725276, guid: 27856c8625bae1e47ba1e4c5a9315383, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4309942965725276, guid: 27856c8625bae1e47ba1e4c5a9315383, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4309942965725276, guid: 27856c8625bae1e47ba1e4c5a9315383, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 4309942965725276, guid: 27856c8625bae1e47ba1e4c5a9315383, type: 2}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 27856c8625bae1e47ba1e4c5a9315383, type: 2}
+  m_IsPrefabParent: 0
 --- !u!1 &632964144
 GameObject:
   m_ObjectHideFlags: 0
@@ -427,7 +479,7 @@ AudioListener:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 970903029}
-  m_Enabled: 1
+  m_Enabled: 0
 --- !u!124 &970903032
 Behaviour:
   m_ObjectHideFlags: 0
@@ -484,90 +536,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 60, y: 0, z: 0}
---- !u!1001 &1436483153
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4378990626526526, guid: 9bd35d4858264da41a2fe184d925a1d8, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4378990626526526, guid: 9bd35d4858264da41a2fe184d925a1d8, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4378990626526526, guid: 9bd35d4858264da41a2fe184d925a1d8, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4378990626526526, guid: 9bd35d4858264da41a2fe184d925a1d8, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0.88327223
-      objectReference: {fileID: 0}
-    - target: {fileID: 4378990626526526, guid: 9bd35d4858264da41a2fe184d925a1d8, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0.10475511
-      objectReference: {fileID: 0}
-    - target: {fileID: 4378990626526526, guid: 9bd35d4858264da41a2fe184d925a1d8, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0.39095134
-      objectReference: {fileID: 0}
-    - target: {fileID: 4378990626526526, guid: 9bd35d4858264da41a2fe184d925a1d8, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 0.23667212
-      objectReference: {fileID: 0}
-    - target: {fileID: 4378990626526526, guid: 9bd35d4858264da41a2fe184d925a1d8, type: 2}
-      propertyPath: m_RootOrder
-      value: 5
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 9bd35d4858264da41a2fe184d925a1d8, type: 2}
-  m_IsPrefabParent: 0
---- !u!1001 &1790334034
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4928511756794582, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4928511756794582, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4928511756794582, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4928511756794582, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0.88327223
-      objectReference: {fileID: 0}
-    - target: {fileID: 4928511756794582, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0.10475511
-      objectReference: {fileID: 0}
-    - target: {fileID: 4928511756794582, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0.39095134
-      objectReference: {fileID: 0}
-    - target: {fileID: 4928511756794582, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 0.23667212
-      objectReference: {fileID: 0}
-    - target: {fileID: 4928511756794582, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 02ffff334dbbaf84cbdd72f66a3c38d8, type: 2}
-  m_IsPrefabParent: 0
 --- !u!1 &1840093358
 GameObject:
   m_ObjectHideFlags: 0
@@ -652,3 +620,45 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &2125659860
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4064583889948694, guid: 95537e0fd822b8f4ebdc507d5bc89986, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 5.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4064583889948694, guid: 95537e0fd822b8f4ebdc507d5bc89986, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4064583889948694, guid: 95537e0fd822b8f4ebdc507d5bc89986, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4064583889948694, guid: 95537e0fd822b8f4ebdc507d5bc89986, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4064583889948694, guid: 95537e0fd822b8f4ebdc507d5bc89986, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 4064583889948694, guid: 95537e0fd822b8f4ebdc507d5bc89986, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 4064583889948694, guid: 95537e0fd822b8f4ebdc507d5bc89986, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4064583889948694, guid: 95537e0fd822b8f4ebdc507d5bc89986, type: 2}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 95537e0fd822b8f4ebdc507d5bc89986, type: 2}
+  m_IsPrefabParent: 0

--- a/Assets/Scripts/Ano/FallEffectSystem.cs
+++ b/Assets/Scripts/Ano/FallEffectSystem.cs
@@ -19,7 +19,6 @@ public class FallEffectSystem : MonoBehaviour {
 
     // Update is called once per frame
     void Update () {
-        this.transform.rotation = Quaternion.Euler(-90.0f, 0.0f, 0.0f);
         if (!MyParticle.isPlaying)
         {
             Destroy(this.gameObject);

--- a/Assets/Scripts/Ano/FireBall.cs
+++ b/Assets/Scripts/Ano/FireBall.cs
@@ -53,7 +53,8 @@ public class FireBall : MonoBehaviour {
 	
 	// Update is called once per frame
 	void Update () {
-        if(!MyParticle.isPlaying)
+        this.transform.rotation = Quaternion.Euler(-90.0f, 0.0f, 0.0f);
+        if (!MyParticle.isPlaying)
         {
             Destroy(this.gameObject);
         }

--- a/Assets/Scripts/Ano/HitSystem.cs
+++ b/Assets/Scripts/Ano/HitSystem.cs
@@ -29,7 +29,19 @@ public class HitSystem : MonoBehaviour {
     {
         //レイヤーの名前取得
         string LayerName = LayerMask.LayerToName(other.gameObject.layer);
-        if ((!HitEffectFlag)&&(PlayerController.EState.Init!= P_Controller.GetMyState()))
+        //プレイヤーオブジェクトに当たったかどうか
+        if (PlayerCheck(other))
+        {
+            //当たったオブジェクトが吹っ飛び状態なのか
+            if(other.gameObject.transform.root.gameObject.GetComponent<PlayerController>().GetMyState()== PlayerController.EState.BlowAway)
+            {
+                return;
+            }
+
+        }
+        if ((!HitEffectFlag)&&
+            ((PlayerController.EState.RightMove== P_Controller.GetMyState())||
+            (PlayerController.EState.LeftMove == P_Controller.GetMyState())))
         {
             //プレイヤーの体判定の部位
             if (LayerName == "Player_Chest")
@@ -163,6 +175,21 @@ public class HitSystem : MonoBehaviour {
         }
 
     }
+    private bool PlayerCheck(Collider col)
+    {
+        string LayerName = LayerMask.LayerToName(col.gameObject.layer);
+        if ((LayerName == "Player_Chest") ||
+            (LayerName == "Player_1") ||
+            (LayerName == "Player_2") ||
+            (LayerName == "Player_3") ||
+            (LayerName == "Player_4") ||
+            (LayerName == "Player_5") ||
+            (LayerName == "Player_6"))
+        {
+            return true;
+        }
+        return false;
+    }
     // Use this for initialization
     void Start () {
 		
@@ -227,6 +254,7 @@ public class HitSystem : MonoBehaviour {
     {
         //親のRigidbodyを探す
         Rigidbody HitRigid = HitObject.transform.root.gameObject.GetComponent<Rigidbody>();
+        HitObject.transform.root.gameObject.GetComponent<PlayerController>().BlowAwayNow();
         switch (EffectType)
         {
             case HitSelect.Hit:

--- a/Assets/Scripts/Date/PlayerController.cs
+++ b/Assets/Scripts/Date/PlayerController.cs
@@ -17,6 +17,8 @@ public class PlayerController : MonoBehaviour
         Init,
         Wait,
         Idle,
+        BlowAway,
+        Atack,
         RightMove,
         LeftMove,
         Dead
@@ -82,7 +84,8 @@ public class PlayerController : MonoBehaviour
     private Rigidbody m_leftHand_rg;
     private Rigidbody m_rightFoot_rg;
     private Rigidbody m_leftFoot_rg;
-
+    // 自分自身の制御オブジェクト (Rigidbody)阿野追加
+    private Rigidbody m_Player_rg;
     private string[] InputName = new string[(int)EInput.MAX];
 
     // 回転する力（パラメータ）
@@ -113,13 +116,19 @@ public class PlayerController : MonoBehaviour
 
     private RayTest.RayDirection dir;
     public RayTest rayTest;
+    //確率
     [Range(0, 100)]
     public int CriticalProbability = 20;
-    [Range(0, 100)]
-    public int HitPower = 20;
-    [Range(0, 100)]
-    public int CriticalPower = 40;
-
+    //ヒット時の力
+    [Range(0, 10)]
+    public float HitPower = 8;
+    //クリティカル時の力
+    [Range(0, 20)]
+    public float CriticalPower = 20;
+    //飛んで動けなくなる制御時間(バグ防止)
+    private float FlayTime_Max = 3;
+    //飛んでる経過時間
+    private float FlayNowTime = 0;
     private bool[] m_isInputFlg = new bool[(int)EInput.MAX];
     void Awake()
     {
@@ -137,7 +146,7 @@ public class PlayerController : MonoBehaviour
         m_leftHand_rg = m_leftHandObj.GetComponent<Rigidbody>();
         m_rightFoot_rg = m_rightFootObj.GetComponent<Rigidbody>();
         m_leftFoot_rg = m_leftFootObj.GetComponent<Rigidbody>();
-
+        m_Player_rg = GetComponent<Rigidbody>();
         m_bodyForce.Init();
         m_HandForce.Init();
         m_FootForce.Init();
@@ -182,7 +191,8 @@ public class PlayerController : MonoBehaviour
     // Update is called once per frame
     void FixedUpdate()
     {
-        if (m_state == EState.Init || m_state == EState.Dead || m_state == EState.Wait) return;
+        if (m_state == EState.Init || m_state == EState.Dead || m_state == EState.Wait|| m_state == EState.BlowAway) return;
+
         // 右方向
         float lsh = Input.GetAxis(InputName[(int)EInput.Horizontal] + myInputManager.joysticks[m_playerID-1].ToString());
         //       Debug.Log("横" + lsh);
@@ -277,7 +287,7 @@ public class PlayerController : MonoBehaviour
             m_HandForce.Init();
             m_FootForce.Init();
         }
-    //    Debug.Log(m_state);
+        //Debug.Log(m_state);
     }
 
 
@@ -368,7 +378,11 @@ public class PlayerController : MonoBehaviour
         if (m_state == EState.Wait) return true;
         return false;
     }
-
+    //吹っ飛び状態にする
+    public void BlowAwayNow()
+    {
+        m_state = EState.BlowAway;
+    }
     // 入力フラグ（クリティカルヒット用）
     public bool IsInputFlagParts(EInput eInput)
     {
@@ -385,6 +399,19 @@ public class PlayerController : MonoBehaviour
     }
     private void OnTriggerEnter(Collider other)
     {
+        //吹っ飛び中に地面に当たると吹っ飛び状態解除
+        if(m_state==EState.BlowAway)
+        {
+            Debug.Log("Player" + PlayerID + "飛んでます");
+            FlayNowTime += Time.deltaTime;
+            if ((LayerMask.LayerToName(other.gameObject.layer) == "Ground")||(FlayNowTime>=FlayTime_Max))
+            {
+                Debug.Log("Player" + PlayerID + "飛び終わりました");
+                FlayNowTime = 0;
+                m_state = EState.Idle;
+            }
+
+        }
         if (m_state != EState.Init) return;
         if (LayerMask.LayerToName(other.gameObject.layer) != "Ground") return;
         m_state = EState.Wait;


### PR DESCRIPTION
動いていない間も攻撃判定つけてしまっていたので修正しました
移動している状態で先に攻撃判定が入った方が吹き飛ばせるようになり、
吹き飛ばされた相手は床に当たるまで再度Hit判定が行かないようにしました。
吹き飛ばしの力をintにしてましたがfloatに変更したので少数調整が可能になりました。
PlayerControllerをだいぶ弄る事になってしまったので競合起きないかチェックお願いします。
前に角度調整した奴が間違ったエフェクトのスプリプトに書いてしまっていたので修正しました。
メテオは突起物に当たっても角度が動かないようにしました。