### PR TITLE
ReadyをコントローラーStartに変更、遷移Timer廃止 

### DIFF
--- a/Assets/Scenes/WarmingUp.unity
+++ b/Assets/Scenes/WarmingUp.unity
@@ -1469,7 +1469,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1140804312
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Ano/WarmingSystem.cs
+++ b/Assets/Scripts/Ano/WarmingSystem.cs
@@ -21,11 +21,17 @@ public class WarmingSystem : MonoBehaviour {
         if(!NextFlag)
         {
             NextSceneTimer -= Time.deltaTime;
-            if ((NextSceneTimer <=0 ) ||(AllReadyCheck()))
+            if (AllReadyCheck())
             {
                 NextFlag = true;
                 SceneController.GetInstance.ChangeScene("GameScene", 2);
             }
+            //if ((NextSceneTimer <=0 ) ||(AllReadyCheck()))
+            //{
+            //    NextFlag = true;
+            //    SceneController.GetInstance.ChangeScene("GameScene", 2);
+            //}
+
         }
 
         for (int i = 0; i < 6; i++)
@@ -49,10 +55,12 @@ public class WarmingSystem : MonoBehaviour {
     }
     void ReadyInput(int Num)
     {
-        if ((Input.GetButton("A_Player" + MyInput.joysticks[Num])) &&
-            (Input.GetButton("B_Player" + MyInput.joysticks[Num]))&&
-            (Input.GetButton("X_Player" + MyInput.joysticks[Num]))&&
-            (Input.GetButton("Y_Player" + MyInput.joysticks[Num])))
+        if (Input.GetButton("ST_Player" + MyInput.joysticks[Num]))
+        {
+            PlayerReadys[Num] = true;
+            Debug.Log("押されたよ" + MyInput.joysticks[Num]);
+        }
+        if (Input.GetKeyDown(KeyCode.Alpha1+ Num))
         {
             PlayerReadys[Num] = true;
             Debug.Log("押されたよ" + MyInput.joysticks[Num]);


### PR DESCRIPTION
Readyをコントローラースタートボタンに変更しました
デバッグ用でキーボード1～6にreadyを割り振っときました
真ん中の数字と時間で遷移をしなくしました